### PR TITLE
fix: msvc intrin SIMDeRenames error

### DIFF
--- a/environ/win32/Application.cpp
+++ b/environ/win32/Application.cpp
@@ -253,8 +253,8 @@ tTVPApplication::~tTVPApplication() {
 #if 0
 struct SEHException {
 	unsigned int Code;
-	_EXCEPTION_POINTERS* ExceptionPointers;
-	SEHException( unsigned int code, _EXCEPTION_POINTERS* ep )
+	::EXCEPTION_POINTERS* ExceptionPointers;
+	SEHException( unsigned int code, ::EXCEPTION_POINTERS* ep )
 		: Code(code), ExceptionPointers(ep)
 	{}
 };
@@ -287,7 +287,7 @@ int TVPWriteHWEDumpFile( EXCEPTION_POINTERS* pExceptionPointers ) {
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 static bool TVPIsHandledHWException = false;
-void se_translator_function(unsigned int code, struct _EXCEPTION_POINTERS* ep) {
+void se_translator_function(unsigned int code, ::EXCEPTION_POINTERS* ep) {
 	if( !TVPIsHandledHWException ) {
 		//ShowStackTrace( ep->ContextRecord );
 		TVPWriteHWEDumpFile( ep );

--- a/sound/PhaseVocoderDSP.cpp
+++ b/sound/PhaseVocoderDSP.cpp
@@ -34,7 +34,6 @@
 
 #define _USE_MATH_DEFINES
 #include <math.h>
-#include "MathAlgorithms.h"
 #include "PhaseVocoderDSP.h"
 #include "RealFFT.h"
 #include <string.h>
@@ -52,6 +51,7 @@
 #include <x86intrin.h>
 #endif
 #endif
+#include "MathAlgorithms.h"
 #ifdef TVP_COMPILING_KRKRSDL2
 // Used: SSE
 #include "SIMDeRenames.h"

--- a/sound/WaveLoopManager.cpp
+++ b/sound/WaveLoopManager.cpp
@@ -55,7 +55,7 @@ const int TVPWaveLoopLinkGiveUpCount = 10;
 	#define TJS_HOST_IS_BIG_ENDIAN 0
 #endif
 
-#ifdef __WIN32__
+#if defined(_WIN32)
 	// for assembler compatibility
 	#pragma pack(push,1)
 #endif
@@ -97,7 +97,7 @@ struct tTVPPCM24
 		return t;
 	}
 };
-#ifdef __WIN32__
+#if defined(_WIN32)
 	#pragma pack(pop)
 #endif
 //---------------------------------------------------------------------------

--- a/tjs2/tjsCommHead.h
+++ b/tjs2/tjsCommHead.h
@@ -20,7 +20,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #define WIN32_LEAN_AND_MEAN
 #ifndef TVP_COMPILING_KRKRSDL2
-#include <SDKDDKVer.h>
+#include <sdkddkver.h>
 #endif
 #include <windows.h>
 

--- a/tjs2/tjsCommHead.h
+++ b/tjs2/tjsCommHead.h
@@ -16,11 +16,11 @@
 #ifndef tjsCommHeadH
 #define tjsCommHeadH
 
-#ifdef __WIN32__
+#if defined(_WIN32)
 #define _CRT_SECURE_NO_WARNINGS
 #define WIN32_LEAN_AND_MEAN
 #ifndef TVP_COMPILING_KRKRSDL2
-#include "targetver.h"
+#include <SDKDDKVer.h>
 #endif
 #include <windows.h>
 

--- a/tjs2/tjsConfig.cpp
+++ b/tjs2/tjsConfig.cpp
@@ -16,7 +16,7 @@
 #include <errno.h>
 //#include <codecvt>
 
-#ifdef __WIN32__
+#if defined(_WIN32)
 #include <float.h>
 #include <intrin.h>
 #endif
@@ -583,7 +583,7 @@ void TJSNativeDebuggerBreak()
 	// debugger, or the program may cause an unhandled debugger breakpoint
 	// exception.
 
-#if defined(__WIN32__)
+#if defined(_WIN32)
 	#if defined(_M_IX86)
 		#ifdef __BORLANDC__
 				__emit__ (0xcc); // int 3 (Raise debugger breakpoint exception)
@@ -603,7 +603,7 @@ void TJSNativeDebuggerBreak()
 //---------------------------------------------------------------------------
 // FPU control
 //---------------------------------------------------------------------------
-#if defined(__WIN32__) && !defined(__GNUC__)
+#if defined(_WIN32) && !defined(__GNUC__)
 static unsigned int TJSDefaultFPUCW = 0;
 static unsigned int TJSNewFPUCW = 0;
 static unsigned int TJSDefaultMMCW = 0;
@@ -612,7 +612,7 @@ static bool TJSFPUInit = false;
 // FPU例外をマスク
 void TJSSetFPUE()
 {
-#if defined(__WIN32__) && !defined(__GNUC__)
+#if defined(_WIN32) && !defined(__GNUC__)
 	if(!TJSFPUInit)
 	{
 		TJSFPUInit = true;
@@ -638,13 +638,13 @@ void TJSSetFPUE()
 //	_fpreset();
 	_control87(TJSNewFPUCW, 0xffff);
 #endif
-#endif	// defined(__WIN32__) && !defined(__GNUC__)
+#endif	// defined(_WIN32) && !defined(__GNUC__)
 
 }
 // 例外マスクを解除し元に戻す
 void TJSRestoreFPUE()
 {
-#if defined(__WIN32__) && !defined(__GNUC__)
+#if defined(_WIN32) && !defined(__GNUC__)
 	if(!TJSFPUInit) return;
 #if defined(_M_X64)
 	_MM_SET_EXCEPTION_MASK(TJSDefaultMMCW);

--- a/tjs2/tjsConfig.h
+++ b/tjs2/tjsConfig.h
@@ -151,7 +151,7 @@ inline bool TJS_iswalpha(tjs_char ch) {
 #elif defined(__GNUC__)
 	#define TJS_cdecl
 	#define TJS_timezone timezone
-#elif __WIN32__
+#elif defined(_WIN32)
 	#define TJS_cdecl __cdecl
 	#define TJS_timezone _timezone
 #endif
@@ -182,7 +182,8 @@ void TJS_debug_out( const tjs_char *format, ... );
 
 #ifdef ANDROID
 #endif
-#ifndef MAX_PATH
+
+#if !defined(MAX_PATH) && !defined(_WIN32)
 #define MAX_PATH 256
 #endif
 

--- a/tjs2/tjsDate.cpp
+++ b/tjs2/tjsDate.cpp
@@ -22,7 +22,7 @@ note:
 	The author assumes that it is a compiler dependented problem, so any remedies
 	are not given here.
 */
-#if 0 && defined(WIN32)
+#if defined(_WIN32)
 typedef struct timeval {
 	time_t tv_sec;
 	long tv_usec;

--- a/tjs2/tjsMath.cpp
+++ b/tjs2/tjsMath.cpp
@@ -15,7 +15,7 @@
 #include "math.h"
 #include "time.h"
 
-#ifdef __WIN32__
+#if defined(_WIN32)
 #ifndef TJS_NO_MASK_MATHERR
 	#include <float.h>
 #endif
@@ -29,7 +29,7 @@
 //---------------------------------------------------------------------------
 // these functions invalidate the mathmarical error
 // (other exceptions, like divide-by-zero error, are not to be caught here)
-#if defined(__WIN32__) && !defined(__GNUC__)
+#if defined(_WIN32) && !defined(__GNUC__)
 #ifndef TJS_NO_MASK_MATHERR
 int _USERENTRY _matherr(struct _exception *e)
 {

--- a/tjs2/tjsUtils.h
+++ b/tjs2/tjsUtils.h
@@ -26,7 +26,7 @@
 #endif
 #endif
 #else
-#ifdef __WIN32__
+#if defined(_WIN32)
 #include <windows.h>
 #else
 #include <semaphore.h>
@@ -82,7 +82,7 @@ public:
 #endif
 };
 #else
-#ifdef __WIN32__
+#if defined(_WIN32)
 class tTJSCriticalSection
 {
 	CRITICAL_SECTION CS;

--- a/visual/GraphicsLoaderIntf.h
+++ b/visual/GraphicsLoaderIntf.h
@@ -285,7 +285,7 @@ extern void TVPLoadGraphic(tTVPBaseBitmap *dest, const ttstr &name, tjs_int keyi
 	#define BI_BITFIELDS	3
 #endif
 
-#ifdef __WIN32__
+#if defined(_WIN32)
 #endif
 #if 1
 #pragma pack(push, 1)
@@ -312,7 +312,7 @@ struct TVP_WIN_BITMAPINFOHEADER
 	tjs_uint32	biClrUsed;
 	tjs_uint32	biClrImportant;
 };
-#ifdef __WIN32__
+#if defined(_WIN32)
 #endif
 #if 1
 #pragma pack(pop)

--- a/visual/LayerBitmapImpl.h
+++ b/visual/LayerBitmapImpl.h
@@ -86,7 +86,7 @@ public:
 #ifdef _WIN32
 #endif
 #if !defined(TVP_COMPILING_KRKRSDL2) && defined(_WIN32)
-	const BITMAPINFO * GetBITMAPINFO() const { return BitmapInfo->GetBITMAPINFO(); }
+	const BITMAPINFO * GetBITMAPINFO() const { return (const BITMAPINFO *)BitmapInfo->GetBITMAPINFO(); }
 	const BITMAPINFOHEADER * GetBITMAPINFOHEADER() const { return (const BITMAPINFOHEADER*)( BitmapInfo->GetBITMAPINFO() ); }
 #endif
 

--- a/visual/argb.h
+++ b/visual/argb.h
@@ -13,7 +13,7 @@
 
 #include "tvpgl.h"
 //---------------------------------------------------------------------------
-#if defined(__WIN32__) || defined(__GNUC__)
+#if defined(_WIN32) || defined(__GNUC__)
 	// for assembler compatibility
 	#pragma pack(push,1)
 #endif
@@ -219,7 +219,7 @@ struct tTVPARGB_AA : public tTVPARGB<base_type>
 
 
 //---------------------------------------------------------------------------
-#if defined(__WIN32__) || defined(__GNUC__)
+#if defined(_WIN32) || defined(__GNUC__)
 	// for assembler compatibility
 	#pragma pack(pop)
 #endif

--- a/visual/gl/ResampleImage.cpp
+++ b/visual/gl/ResampleImage.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #define _USE_MATH_DEFINES
+#include "aligned_allocator.h"
 #include "tjsCommHead.h"
 
 #include <float.h>
@@ -30,7 +31,6 @@
 #include "WeightFunctor.h"
 #include "ThreadIntf.h"
 
-#include "aligned_allocator.h"
 #include "ResampleImageInternal.h"
 
 

--- a/visual/gl/ResampleImageAVX2.cpp
+++ b/visual/gl/ResampleImageAVX2.cpp
@@ -2,6 +2,7 @@
 
 #define _USE_MATH_DEFINES
 
+#include "aligned_allocator.h"
 #include "tjsCommHead.h"
 #include "LayerBitmapIntf.h"
 #include "LayerBitmapImpl.h"
@@ -22,7 +23,6 @@
 #endif
 
 #include "x86simdutil.h"
-#include "aligned_allocator.h"
 
 #include "WeightFunctorAVX.h"
 #include "ResampleImageInternal.h"

--- a/visual/gl/ResampleImageSSE2.cpp
+++ b/visual/gl/ResampleImageSSE2.cpp
@@ -2,6 +2,7 @@
 
 #define _USE_MATH_DEFINES
 
+#include "aligned_allocator.h"
 #include "tjsCommHead.h"
 #include "LayerBitmapIntf.h"
 #include "LayerBitmapImpl.h"
@@ -21,7 +22,6 @@
 #endif
 
 #include "x86simdutil.h"
-#include "aligned_allocator.h"
 
 #include "WeightFunctorSSE.h"
 #include "ResampleImageInternal.h"


### PR DESCRIPTION
- \_\_WIN32\_\_ change to _WIN32
- msvc SIMDeRenames error